### PR TITLE
Update Build Status Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm i unleash -DE
   * E.g. `"2.6.4-beta.0"` => `"2.6.4-beta.1"`
   
 ### Badge-o-rama
-![Travis badge](https://travis-ci.org/Netflix/unleash.svg)
+![Travis badge](https://travis-ci.com/Netflix/unleash.svg)
 
 <img src="https://c2.staticflickr.com/4/3738/11674920374_34acde064b_b.jpg" width="400">
 


### PR DESCRIPTION
This build has been migrated to travis-ci.com as per their [recommendation](https://mailchi.mp/3d439eeb1098/travis-ciorg-is-moving-to-travis-cicom).